### PR TITLE
Update to ws ^0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "4.0"
   - "0.12"
   - "0.10"
   - "iojs"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eventemitter2": "^0.4.14",
     "node-libs-browser": ">= 0.4.0 <=0.6.0",
     "rethinkdb": "^2.0.0",
-    "ws": "^0.7.2"
+    "ws": "^0.8.0"
   },
   "devDependencies": {
     "babel": "^5.5.6",


### PR DESCRIPTION
The version of ws currently used does not compile on Node v4. Upgrading to ws 0.8.0 fixes this problem
