### PR TITLE
Support ES6 import syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,17 @@ function connect({host, port, path, secure, wsProtocols, db, simulatedLatencyMs}
   return connectionPromise;
 }
 
+const RethinkdbWebsocketClient = {
+  rethinkdb,
+  protodef,
+  Promise,
+  connect,
+};
+
 export {
   rethinkdb,
   protodef,
   Promise,
   connect,
+  RethinkdbWebsocketClient as default,
 };


### PR DESCRIPTION
Ha, I found another way

```
import RethinkdbWebsocketClient from "rethinkdb-websocket-client"
```

works now.
