### PR TITLE
Add support for changing ws binary type

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ var options = {
   port: 8015,              // port number of the websocket server
   path: '/',               // HTTP path to websocket route
   wsProtocols: ['binary'], // sub-protocols for websocket, required for websockify
-  wsBinary: 'arraybuffer'  // specify which binary type should be used for WS (optional)
+  wsBinary: 'arraybuffer',  // specify which binary type should be used for WS (optional)
   secure: false,           // set true to use secure TLS websockets
   db: 'test',              // default database, passed to rethinkdb.connect
   simulatedLatencyMs: 100, // wait 100ms before sending each message (optional)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ var options = {
   port: 8015,              // port number of the websocket server
   path: '/',               // HTTP path to websocket route
   wsProtocols: ['binary'], // sub-protocols for websocket, required for websockify
+  wsBinary: 'arraybuffer'  // specify which binary type should be used for WS (optional)
   secure: false,           // set true to use secure TLS websockets
   db: 'test',              // default database, passed to rethinkdb.connect
   simulatedLatencyMs: 100, // wait 100ms before sending each message (optional)

--- a/src/TcpPolyfill.js
+++ b/src/TcpPolyfill.js
@@ -16,6 +16,7 @@ export function configureTcpPolyfill(options) {
   tcpPolyfillOptions.path = options.path;
   tcpPolyfillOptions.secure = options.secure;
   tcpPolyfillOptions.wsProtocols = options.wsProtocols;
+  tcpPolyfillOptions.wsBinaryType = options.wsBinaryType;
   tcpPolyfillOptions.simulatedLatencyMs = options.simulatedLatencyMs;
 }
 
@@ -37,6 +38,11 @@ export function Socket(options) {
     const path = tcpPolyfillOptions.path;
     const url = `${protocol}://${host}:${port}${path}`;
     ws = new WebSocket(url, tcpPolyfillOptions.wsProtocols);
+
+    if (tcpPolyfillOptions.wsBinaryType) {
+      ws.binaryType = tcpPolyfillOptions.wsBinaryType;
+    }
+
     if (connectListener) {
       emitter.on('connect', connectListener);
     }
@@ -99,6 +105,8 @@ export function Socket(options) {
           }
           emitter.emit('data', buffer);
         });
+      } else if (typeof ArrayBuffer !== 'undefined' && data instanceof ArrayBuffer) {
+        emitter.emit('data', Buffer.from(data));
       } else if (handleBase64) {
         emitter.emit('data', new Buffer(data, 'base64'));
       } else {

--- a/src/TcpPolyfill.js
+++ b/src/TcpPolyfill.js
@@ -5,6 +5,7 @@ let tcpPolyfillOptions = {
   path: '/',
   secure: false,
   wsProtocols: undefined,
+  wsBinaryType: undefined,
   simulatedLatencyMs: undefined,
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@ import rethinkdb from 'rethinkdb';
 import protodef from 'rethinkdb/proto-def';
 import {configureTcpPolyfill} from './TcpPolyfill';
 
-function connect({host, port, path, secure, wsProtocols, db, simulatedLatencyMs}) {
-  configureTcpPolyfill({path, secure, wsProtocols, simulatedLatencyMs});
+function connect({host, port, path, secure, wsProtocols, wsBinaryType, db, simulatedLatencyMs}) {
+  configureTcpPolyfill({path, secure, wsProtocols, wsBinaryType, simulatedLatencyMs});
   // Temporarily unset process.browser so rethinkdb uses a TcpConnection
   const oldProcessDotBrowser = process.browser;
   process.browser = false;


### PR DESCRIPTION
These code changes allow to define which binary type will be used for WS connection (and corresponding message processing with type conversion ArrayBuffer -> Buffer). Using 'arraybuffer' basically fixes issues like https://github.com/mikemintz/rethinkdb-websocket-server/issues/19 by doing type conversion in a sync way (unlike from blobToBuffer call)